### PR TITLE
Overwrite help urls from .env

### DIFF
--- a/app/Http/Controllers/HelpController.php
+++ b/app/Http/Controllers/HelpController.php
@@ -24,11 +24,17 @@ class HelpController extends Controller
 
     public function imprint()
     {
+        if (config('help.imprint_redirect')) {
+            return redirect(config('help.imprint_redirect'));
+        }
         return view('help.imprint');
     }
 
     public function privacy()
     {
+        if (config('help.privacy_redirect')) {
+            return redirect(config('help.privacy_redirect'));
+        }
         return view('help.privacy');
     }
 }

--- a/config/help.php
+++ b/config/help.php
@@ -1,8 +1,12 @@
 <?php
 
-$url = 'https://fizban05.rz.tu-harburg.de/itbh/portfolio-team/portfolio-hilfe';
+$url = env('HELP_URL', 'https://fizban05.rz.tu-harburg.de/itbh/portfolio-team/portfolio-hilfe');
 
 return [
+    // redirects can be set, to overwrite pages with external links
+    'imprint_redirect' => env('IMPRINT_URL', false),
+    'privacy_redirect' => env('PRIVACY_URL', false),
+
     'dashboard' => $url . '/dashboard/hilfe_dashboard.html',
     'profile' => [
         'personal' => $url . '/profil/hilfe_profil_persoenlich.html',


### PR DESCRIPTION
This PR adds variables for setting external urls for:

- Hilfe Button (Header)
- Impressum Link (Footer)
- Datenschutz Link (Footer)

Impress/Privacy are redirected from laravel controller, links stay the same.

Regarding "Help": No idea if and how the crawler thing is still in use. Thus I only replaced the link in the header.